### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/daveonplanetearth0334/a9d406a1-aede-40e3-b07e-85826d0c34c4/0ad7430d-cb77-42e6-8827-d9fcd3bdce32/_apis/work/boardbadge/e2ab6bb3-2063-46fa-8901-9551803b0abe)](https://dev.azure.com/daveonplanetearth0334/a9d406a1-aede-40e3-b07e-85826d0c34c4/_boards/board/t/0ad7430d-cb77-42e6-8827-d9fcd3bdce32/Microsoft.RequirementCategory)
 # az400-integration


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/daveonplanetearth0334/a9d406a1-aede-40e3-b07e-85826d0c34c4/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.